### PR TITLE
docs: update commit message guidelines in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -30,8 +30,12 @@ We would like to express our heartfelt thanks to all the amazing contributors wh
 - *Batch/Year*: Senior Software Developer (7+ Years Experience)
 - *Joined*: December 2024
 
-
-
+### **Dipesh B C**
+- **Role/Contribution**: Maintainer
+- **GitHub**: [Dipesh B C](https://github.com/bcdipesh)
+- **LinkedIn**: [Dipesh B C](https://www.linkedin.com/in/dipeshbc)
+- **Batch/Year**: Software Engineer (5+ Years Experience)
+- **Joined**: December 2024
 
 
 ---
@@ -45,4 +49,3 @@ To add yourself as a contributor, please follow these steps:
 Thank you for being a part of this community, and we look forward to more contributions!
 
 ---
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,10 +94,7 @@ We welcome contributions in various forms:
 - Keep functions small and focused
 
 ### Commit Message Guidelines
-- Use present tense
-- Use imperative mood
-- Be concise and descriptive
-- Example: "Add user authentication module"
+- Please follow the [commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) guidelines provided by the Angular team at Google. 
 
 ## Code Review Process
 
@@ -123,7 +120,7 @@ We welcome contributions in various forms:
 
 ## Code of Conduct
 
-Please read our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before contributing.
+Please read our [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) before contributing.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We are a group of passionate students from ASCOL committed to:
    - Join our Discord/Slack (link to be added)
 
 2. **First-Time Contributors**
-   - Check out our [CONTRIBUTERS.md](contributers.md) guide
+   - Check out our [CONTRIBUTERS.md](./CONTRIBUTERS.md) guide
    - Look for "good first issue" labels in our repositories
    - Attend our weekly tech meetups
 
@@ -77,7 +77,7 @@ We welcome contributions from:
 
 ## Code of Conduct 📜
 
-Please read our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) to understand our community standards and expectations.
+Please read our [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) to understand our community standards and expectations.
 
 ## Connect With Us 🌐
 


### PR DESCRIPTION
Update commit message guidelines to add link to commit message format guidelines provided by the Angular team at Google. This is only a recommendation. This format leads to easier to read commit history.